### PR TITLE
Closes #3. Add missing lang definitions.

### DIFF
--- a/lang/en/tiny_fileimport.php
+++ b/lang/en/tiny_fileimport.php
@@ -35,5 +35,5 @@ $string['allowedextensionsoverride'] = 'Allowed file extensions override';
 $string['allowedextensionsoverride_desc'] = 'Optional. Comma, space, or newline separated list of extensions to allow (for example: pdf, docx, xlsx, zip). If empty, the plugin uses the full list from Site administration > Server > File types. Ignored when "Allow all file types" is enabled.';
 $string['filetypenotsupported'] = 'File type not supported';
 $string['filetypenotsupported_desc'] = 'The file \"{$a}\" could not be uploaded because its file type is not supported by the current settings.';
-$string['tiny/fileimport:use'] = 'Use Tiny file import';
+$string['fileimport:use'] = 'Use Tiny file import';
 $string['privacy:metadata'] = 'The Tiny file import plugin does not store any personal data.';

--- a/lang/fi/tiny_fileimport.php
+++ b/lang/fi/tiny_fileimport.php
@@ -35,5 +35,5 @@ $string['allowedextensionsoverride'] = 'Sallittujen tiedostopäätteiden ohitus'
 $string['allowedextensionsoverride_desc'] = 'Valinnainen. Pilkulla, välilyönnillä tai rivinvaihdolla erotettu luettelo sallituista tiedostopäätteistä (esimerkiksi: pdf, docx, xlsx, zip). Jos tyhjä, lisäosa käyttää täydellistä luetteloa sivuston hallinnosta > Palvelin > Tiedostotyypit. Ohitetaan, kun "Salli kaikki tiedostotyypit" on käytössä.';
 $string['filetypenotsupported'] = 'Tiedostotyyppi ei ole tuettu';
 $string['filetypenotsupported_desc'] = 'Tiedostoa "{$a}" ei voitu ladata, koska sen tiedostotyyppi ei ole tuettu nykyisten asetusten mukaan.';
-$string['tiny/fileimport:use'] = 'Käytä Tiny-tiedostojen tuontia';
+$string['fileimport:use'] = 'Käytä Tiny-tiedostojen tuontia';
 $string['privacy:metadata'] = 'Tiny-tiedostojen tuonti -lisäosa ei tallenna henkilötietoja.';


### PR DESCRIPTION
This pull request makes a minor update to language string keys related to the Tiny file import plugin. Specifically, it standardizes the capability string identifier by removing the `tiny/` prefix in both English and Finnish language files.

- Language string key update:
  * Changed the capability string from `tiny/fileimport:use` to `fileimport:use` in both `lang/en/tiny_fileimport.php` and `lang/fi/tiny_fileimport.php` to ensure consistency and likely to match capability definitions elsewhere. [[1]](diffhunk://#diff-b09340cbe4c9d22480eb039851cfe4e85b9f0c399814346efb36e85edae5aa47L38-R38) [[2]](diffhunk://#diff-39397861101f3af7a71055763e81c6fbbb8085110b3ee01885c8c033f7b9b3e2L38-R38)